### PR TITLE
fix: unlike kind, minikube has a .exe extension

### DIFF
--- a/src/minikube-installer.ts
+++ b/src/minikube-installer.ts
@@ -44,7 +44,7 @@ const MACOS_X64_PLATFORM = 'darwin-x64';
 
 const MACOS_ARM64_PLATFORM = 'darwin-arm64';
 
-const WINDOWS_X64_ASSET_NAME = 'minikube-windows-amd64';
+const WINDOWS_X64_ASSET_NAME = 'minikube-windows-amd64.exe';
 
 const LINUX_X64_ASSET_NAME = 'minikube-linux-amd64';
 
@@ -128,7 +128,7 @@ export class MinikubeInstaller {
               });
               progress.report({ increment: 80 });
               if (asset) {
-                const destFile = path.resolve(this.storagePath, isWindows() ? assetInfo.name + '.exe' : assetInfo.name);
+                const destFile = path.resolve(this.storagePath, assetInfo.name);
                 if (!fs.existsSync(this.storagePath)) {
                   fs.mkdirSync(this.storagePath);
                 }


### PR DESCRIPTION
In the kind instructions, they _rename_ it after download...

https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-release-binaries

But in minikube, it has the right name (.exe) from the start

Closes #9 