### PR TITLE
Resolves #33 Respect MINIKUBE_HOME env variable

### DIFF
--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { getMinikubePath, runCliCommand } from './util';
+import { getMinikubePath, getMinikubeHome, runCliCommand } from './util';
 
 import type { Logger, TelemetryLogger, CancellationToken } from '@podman-desktop/api';
 
@@ -49,6 +49,9 @@ export async function createCluster(
 
   // update PATH to include minikube
   env.PATH = getMinikubePath();
+
+  // respect MINIKUBE_HOME
+  env.MINIKUBE_HOME = getMinikubeHome();
 
   // now execute the command to create the cluster
   try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,12 +17,13 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { detectMinikube, getMinikubePath, runCliCommand } from './util';
+import { detectMinikube, getMinikubePath, getMinikubeHome, runCliCommand } from './util';
 import { MinikubeInstaller } from './minikube-installer';
 import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
 import { ImageHandler } from './image-handler';
 import { createCluster } from './create-cluster';
+import { get } from 'node:http';
 
 const API_MINIKUBE_INTERNAL_API_PORT = 8443;
 
@@ -123,6 +124,7 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
         delete: async (logger): Promise<void> => {
           const env = Object.assign({}, process.env);
           env.PATH = getMinikubePath();
+          env.MINIKUBE_HOME = getMinikubeHome();
           await runCliCommand(minikubeCli, ['delete', '--profile', cluster.name], { env, logger });
         },
       };

--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -18,8 +18,9 @@
 import type { MinikubeCluster } from './extension';
 import * as extensionApi from '@podman-desktop/api';
 import { tmpName } from 'tmp-promise';
-import { getMinikubePath, runCliCommand } from './util';
+import { getMinikubePath, getMinikubeHome, runCliCommand } from './util';
 import * as fs from 'node:fs';
+import { get } from 'node:http';
 
 type ImageInfo = { engineId: string; name?: string; tag?: string };
 
@@ -63,6 +64,7 @@ export class ImageHandler {
       }
 
       env.PATH = getMinikubePath();
+      env.MINIKUBE_HOME = getMinikubeHome();
       try {
         // Create a temporary file to store the image
         filename = await tmpName();

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -20,7 +20,7 @@
 
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { detectMinikube, getMinikubePath, installBinaryToSystem, runCliCommand } from './util';
+import { detectMinikube, getMinikubePath, getMinikubeHome, installBinaryToSystem, runCliCommand } from './util';
 import * as childProcess from 'node:child_process';
 import type { MinikubeInstaller } from './minikube-installer';
 import * as fs from 'node:fs';
@@ -84,6 +84,26 @@ test('getMinikubePath on macOS with existing PATH', async () => {
 
   const computedPath = getMinikubePath();
   expect(computedPath).toEqual(`${existingPATH}:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin`);
+});
+
+test('getMinikubeHome returns default minikube from user home', async () => {
+  delete process.env.MINIKUBE_HOME;
+
+  const mockHOME = '/tmp';
+  process.env.HOME = mockHOME;
+
+  const computedPath = getMinikubeHome();
+  expect(computedPath).toEqual(`${mockHOME}/.minikube`);
+});
+
+test('getMinikubeHome returns MINIKUBE_HOME from environment', async () => {
+  delete process.env.MINIKUBE_HOME;
+
+  const mockMINIKUBE_HOME = '/custom-minikube-home';
+  process.env.MINIKUBE_HOME = mockMINIKUBE_HOME;
+
+  const computedPath = getMinikubeHome();
+  expect(computedPath).toEqual(mockMINIKUBE_HOME);
 });
 
 test.each([

--- a/src/util.ts
+++ b/src/util.ts
@@ -50,10 +50,19 @@ export function getMinikubePath(): string {
   }
 }
 
+export function getMinikubeHome(): string {
+  const env = process.env
+  if (!env.MINIKUBE_HOME || env.MINIKUBE_HOME === '') {
+    return path.join(os.homedir(), '.minikube')
+  } else {
+    return env.MINIKUBE_HOME
+  }
+}
+
 // search if minikube is available in the path
 export async function detectMinikube(pathAddition: string, installer: MinikubeInstaller): Promise<string> {
   try {
-    await runCliCommand('minikube', ['version'], { env: { PATH: getMinikubePath() } });
+    await runCliCommand('minikube', ['version'], { env: { PATH: getMinikubePath(), MINIKUBE_HOME: getMinikubeHome() } });
     return 'minikube';
   } catch (e) {
     // ignore and try another way
@@ -63,7 +72,10 @@ export async function detectMinikube(pathAddition: string, installer: MinikubeIn
   if (assetInfo) {
     try {
       await runCliCommand(assetInfo.name, ['version'], {
-        env: { PATH: getMinikubePath().concat(path.delimiter).concat(pathAddition) },
+        env: {
+          PATH: getMinikubePath().concat(path.delimiter).concat(pathAddition),
+          MINIKUBE_HOME: getMinikubeHome()
+        },
       });
       return pathAddition
         .concat(path.sep)


### PR DESCRIPTION
Resolves #33 - Passing `MINIKUBE_HOME` env variable along with `PATH` into `runCliCommand` to prevent duplicates of minikube's state and configurations