### PR TITLE
fix: update podman api and replace local runCliCommand with process.exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "podman-desktop",
   "license": "Apache-2.0",
   "engines": {
-    "podman-desktop": "^1.0.0"
+    "podman-desktop": ">=1.10.0"
   },
   "main": "./dist/extension.js",
   "contributes": {
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "7zip-min": "^1.4.4",
-    "@podman-desktop/api": "^1.6.4",
+    "@podman-desktop/api": "^1.10.0",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
     "@vitest/coverage-v8": "^1.2.1",

--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -15,9 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { getMinikubePath, runCliCommand } from './util';
+import { getMinikubePath } from './util';
 
 import type { Logger, TelemetryLogger, CancellationToken } from '@podman-desktop/api';
+import { process as processApi } from '@podman-desktop/api';
 
 export async function createCluster(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,7 +53,7 @@ export async function createCluster(
 
   // now execute the command to create the cluster
   try {
-    await runCliCommand(minikubeCli, startArgs, { env, logger }, token);
+    await processApi.exec(minikubeCli, startArgs, { env, logger, token });
     telemetryLogger.logUsage('createCluster', { driver, runtime });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : error;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import * as extensionApi from '@podman-desktop/api';
-import { detectMinikube, getMinikubePath, runCliCommand } from './util';
+import { detectMinikube, getMinikubePath } from './util';
 import { MinikubeInstaller } from './minikube-installer';
 import type { CancellationToken, Logger } from '@podman-desktop/api';
 import { window } from '@podman-desktop/api';
@@ -123,7 +123,7 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
         delete: async (logger): Promise<void> => {
           const env = Object.assign({}, process.env);
           env.PATH = getMinikubePath();
-          await runCliCommand(minikubeCli, ['delete', '--profile', cluster.name], { env, logger });
+          await extensionApi.process.exec(minikubeCli, ['delete', '--profile', cluster.name], { env, logger });
         },
       };
       // create a new connection

--- a/src/image-handler.spec.ts
+++ b/src/image-handler.spec.ts
@@ -21,13 +21,16 @@ import type { Mock } from 'vitest';
 import { ImageHandler } from './image-handler';
 import * as extensionApi from '@podman-desktop/api';
 import * as fs from 'node:fs';
-import { getMinikubePath, runCliCommand } from './util';
+import { getMinikubePath } from './util';
 
 let imageHandler: ImageHandler;
 vi.mock('@podman-desktop/api', async () => {
   return {
     containerEngine: {
       saveImage: vi.fn(),
+    },
+    process: {
+      exec: vi.fn(),
     },
     window: {
       showNotification: vi.fn(),
@@ -38,7 +41,6 @@ vi.mock('@podman-desktop/api', async () => {
 
 vi.mock('./util', async () => {
   return {
-    runCliCommand: vi.fn().mockReturnValue({ exitCode: 0 }),
     getMinikubePath: vi.fn(),
   };
 });
@@ -119,9 +121,9 @@ test('expect cli is called with right PATH', async () => {
   );
   expect(getMinikubePath).toBeCalled();
 
-  expect(runCliCommand).toBeCalledTimes(1);
-  // grab the env parameter of the first call to runCliCommand
-  const props = (runCliCommand as Mock).mock.calls[0][2];
+  expect(extensionApi.process.exec).toBeCalledTimes(1);
+  // grab the env parameter of the first call to process.Exec
+  const props = (extensionApi.process.exec as Mock).mock.calls[0][2];
   expect(props).to.have.property('env');
   const env = props.env;
   expect(env).to.have.property('PATH');

--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -18,7 +18,7 @@
 import type { MinikubeCluster } from './extension';
 import * as extensionApi from '@podman-desktop/api';
 import { tmpName } from 'tmp-promise';
-import { getMinikubePath, runCliCommand } from './util';
+import { getMinikubePath } from './util';
 import * as fs from 'node:fs';
 
 type ImageInfo = { engineId: string; name?: string; tag?: string };
@@ -71,7 +71,7 @@ export class ImageHandler {
         await extensionApi.containerEngine.saveImage(image.engineId, name, filename);
 
         // Run the minikube image load command to push the image to the cluster
-        await runCliCommand(minikubeCli, ['-p', selectedCluster.label, 'image', 'load', filename], {
+        await extensionApi.process.exec(minikubeCli, ['-p', selectedCluster.label, 'image', 'load', filename], {
           env: env,
         });
 

--- a/src/minikube-installer.spec.ts
+++ b/src/minikube-installer.spec.ts
@@ -60,10 +60,6 @@ const telemetryLoggerMock = {
   logError: telemetryLogErrorMock,
 } as unknown as extensionApi.TelemetryLogger;
 
-vi.mock('runCliCommand', async () => {
-  return vi.fn();
-});
-
 beforeEach(() => {
   installer = new MinikubeInstaller('.', telemetryLoggerMock);
   vi.clearAllMocks();

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -20,8 +20,7 @@
 
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
-import { detectMinikube, getMinikubePath, installBinaryToSystem, runCliCommand } from './util';
-import * as childProcess from 'node:child_process';
+import { detectMinikube, getMinikubePath, installBinaryToSystem } from './util';
 import type { MinikubeInstaller } from './minikube-installer';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -86,36 +85,16 @@ test('getMinikubePath on macOS with existing PATH', async () => {
   expect(computedPath).toEqual(`${existingPATH}:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin`);
 });
 
-test.each([
-  ['macOS', true, false],
-  ['windows', false, true],
-])('detectMinikube on %s', async (operatingSystem, isMac, isWindows) => {
-  vi.mocked(extensionApi.env).isMac = isMac;
-  vi.mocked(extensionApi.env).isWindows = isWindows;
-
-  // spy on runCliCommand
-  const spawnSpy = vi.spyOn(childProcess, 'spawn');
-
-  const onEventMock = vi.fn();
-
-  onEventMock.mockImplementation((event: string, callback: (data: string) => void) => {
-    // delay execution
-    if (event === 'close') {
-      setTimeout(() => {
-        callback(0 as unknown as string);
-      }, 500);
-    }
-  });
-
-  spawnSpy.mockReturnValue({
-    on: onEventMock,
-    stdout: { setEncoding: vi.fn(), on: vi.fn() },
-    stderr: { setEncoding: vi.fn(), on: vi.fn() },
-  } as unknown as childProcess.ChildProcessWithoutNullStreams);
-
+test('detectMinikube', async () => {
   const fakeMinikubeInstaller = {
     getAssetInfo: vi.fn(),
   } as unknown as MinikubeInstaller;
+
+  const execMock = vi.spyOn(extensionApi.process, 'exec').mockResolvedValue({
+    command: '',
+    stderr: '',
+    stdout: '',
+  });
 
   const result = await detectMinikube('', fakeMinikubeInstaller);
   expect(result).toEqual('minikube');
@@ -123,89 +102,10 @@ test.each([
   // expect not called getAssetInfo
   expect(fakeMinikubeInstaller.getAssetInfo).not.toBeCalled();
 
-  expect(spawnSpy).toBeCalled();
+  expect(execMock).toBeCalled();
   // expect right parameters
-  if (isMac) {
-    expect(spawnSpy.mock.calls[0][0]).toEqual('minikube');
-  } else if (isWindows) {
-    expect(spawnSpy.mock.calls[0][0]).toEqual('"minikube"');
-  }
-  expect(spawnSpy.mock.calls[0][1]).toEqual(['version']);
-});
-
-test('runCliCommand/killProcess on macOS', async () => {
-  vi.mocked(extensionApi.env).isMac = true;
-  vi.mocked(extensionApi.env).isWindows = false;
-
-  // spy on runCliCommand
-  const spawnSpy = vi.spyOn(childProcess, 'spawn');
-
-  const killMock = vi.fn();
-
-  spawnSpy.mockReturnValue({
-    kill: killMock,
-    on: vi.fn(),
-    stdout: { setEncoding: vi.fn(), on: vi.fn() },
-    stderr: { setEncoding: vi.fn(), on: vi.fn() },
-  } as unknown as childProcess.ChildProcessWithoutNullStreams);
-
-  const fakeToken = {
-    onCancellationRequested: vi.fn(),
-  } as unknown as extensionApi.CancellationToken;
-
-  vi.mocked(fakeToken.onCancellationRequested).mockImplementation((callback: any): extensionApi.Disposable => {
-    // abort execution after 500ms
-    setTimeout(() => {
-      callback();
-    }, 500);
-
-    return extensionApi.Disposable.from({ dispose: vi.fn() });
-  });
-
-  await expect(runCliCommand('fooCommand', [], undefined, fakeToken)).rejects.toThrow('Execution cancelled');
-
-  expect(spawnSpy.mock.calls[0][0]).toEqual('fooCommand');
-
-  expect(killMock).toBeCalled();
-});
-
-test('runCliCommand/killProcess on Windows', async () => {
-  vi.mocked(extensionApi.env).isMac = false;
-  vi.mocked(extensionApi.env).isWindows = true;
-
-  // spy on runCliCommand
-  const spawnSpy = vi.spyOn(childProcess, 'spawn');
-
-  const killMock = vi.fn();
-
-  spawnSpy.mockReturnValue({
-    kill: killMock,
-    pid: 'pid123',
-    on: vi.fn(),
-    stdout: { setEncoding: vi.fn(), on: vi.fn() },
-    stderr: { setEncoding: vi.fn(), on: vi.fn() },
-  } as unknown as childProcess.ChildProcessWithoutNullStreams);
-
-  const fakeToken = {
-    onCancellationRequested: vi.fn(),
-  } as unknown as extensionApi.CancellationToken;
-
-  vi.mocked(fakeToken.onCancellationRequested).mockImplementation((callback: any): extensionApi.Disposable => {
-    // abort execution after 500ms
-    setTimeout(() => {
-      callback();
-    }, 500);
-
-    return extensionApi.Disposable.from({ dispose: vi.fn() });
-  });
-
-  await expect(runCliCommand('fooCommand', [], undefined, fakeToken)).rejects.toThrow('Execution cancelled');
-
-  expect(spawnSpy.mock.calls[0][0]).toEqual('"fooCommand"');
-  // on windows we don't use killProcess but run taskkill
-  expect(killMock).not.toBeCalled();
-
-  expect(spawnSpy.mock.calls[1]).toEqual(['taskkill', ['/pid', 'pid123', '/f', '/t']]);
+  expect(execMock.mock.calls[0][0]).toEqual('minikube');
+  expect(execMock.mock.calls[0][1]).toEqual(['version']);
 });
 
 test('error: expect installBinaryToSystem to fail with a non existing binary', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -394,10 +394,10 @@
   dependencies:
     esquery "^1.4.0"
 
-"@podman-desktop/api@^1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.6.4.tgz#f6da8228523e787f408d366f1d99d12a7b9e6924"
-  integrity sha512-8sxPcFvepxVM0iANq9h+QbnxAPAEE03KhrDTUp8AEzMPHZhascBSi11xhaLaDUujXVaKHUysEt0hh+0ccL479w==
+"@podman-desktop/api@^1.10.0":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@podman-desktop/api/-/api-1.10.2.tgz#5e528318848d901beeeb3eaf3105806e2b72f9ac"
+  integrity sha512-QcfzlQXBXA2p3wAHpt0m2ss5x4vQVx8H5i+u0aAgdYm3BHoJBr/Xq7Hvnd+Vqypz5AogUPYjejJ9o3UMx1OS3w==
 
 "@rollup/rollup-android-arm-eabi@4.9.6":
   version "4.9.6"


### PR DESCRIPTION
This PR just updates the podman desktop api and replace the runCliCommand with the process.exec function from the api.