### PR TITLE
chore: push statusBarItem to subscriptions to be disposed correctly

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -258,6 +258,7 @@ export async function activate(extensionContext: extensionApi.ExtensionContext):
             (err: unknown) => window.showErrorMessage('Minikube installation failed ' + err),
           ),
         ),
+        statusBarItem,
       );
       statusBarItem.show();
     }


### PR DESCRIPTION
This PR just pushes the statusBaritem to subscriptions so when the extension gets disactivated the item gets disposed and removed from the statusBar. This prevents having duplicates.

It resolves #21 