### PR TITLE
fix: use minikube cli to start/stop cluster

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -109,8 +109,9 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
       const lifecycle: extensionApi.ProviderConnectionLifecycle = {
         start: async (): Promise<void> => {
           try {
-            // start the container
-            await extensionApi.containerEngine.startContainer(cluster.engineId, cluster.id);
+            const env = Object.assign({}, process.env);
+            env.PATH = getMinikubePath();
+            await extensionApi.process.exec(minikubeCli, ['start', '--profile', cluster.name], { env });
           } catch (err) {
             console.error(err);
             // propagate the error
@@ -118,7 +119,9 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
           }
         },
         stop: async (): Promise<void> => {
-          await extensionApi.containerEngine.stopContainer(cluster.engineId, cluster.id);
+          const env = Object.assign({}, process.env);
+          env.PATH = getMinikubePath();
+          await extensionApi.process.exec(minikubeCli, ['stop', '--profile', cluster.name, '--keep-context-active'], { env });
         },
         delete: async (logger): Promise<void> => {
           const env = Object.assign({}, process.env);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,9 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
         stop: async (): Promise<void> => {
           const env = Object.assign({}, process.env);
           env.PATH = getMinikubePath();
-          await extensionApi.process.exec(minikubeCli, ['stop', '--profile', cluster.name, '--keep-context-active'], { env });
+          await extensionApi.process.exec(minikubeCli, ['stop', '--profile', cluster.name, '--keep-context-active'], {
+            env,
+          });
         },
         delete: async (logger): Promise<void> => {
           const env = Object.assign({}, process.env);


### PR DESCRIPTION
This resolves #45 

So far we were starting the existing minikube cluster just by starting/stopping the minikube container. Unfortunately this is not enough. Even though the container was started, the minikube cluster remained stopped. 

The minikube start command is responsible to start all features and handle all the process.

