### PR TITLE
feat: adding find minikube util method

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -25,6 +25,8 @@ import type { Octokit } from '@octokit/rest';
 import type * as extensionApi from '@podman-desktop/api';
 import { env } from '@podman-desktop/api';
 
+import { whereBinary } from './util';
+
 export interface MinikubeGithubReleaseArtifactMetadata {
   tag: string;
   id: number;
@@ -72,6 +74,22 @@ export class MinikubeDownload {
       fileExtension = '.exe';
     }
     return path.resolve(this.extensionContext.storagePath, `minikube${fileExtension}`);
+  }
+
+  /**
+   * search if minikube is available in the path or in the extension folder
+   */
+  async findMinikube(): Promise<string | undefined> {
+    try {
+      return await whereBinary('minikube');
+    } catch (err: unknown) {
+      console.debug(err);
+    }
+
+    const extensionPath = this.getMinikubeExtensionPath();
+    if (fs.existsSync(extensionPath)) {
+      return extensionPath;
+    }
   }
 
   // Download minikube from the artifact metadata: MinikubeGithubReleaseArtifactMetadata

--- a/src/minikube-installer.ts
+++ b/src/minikube-installer.ts
@@ -56,6 +56,9 @@ const MACOS_X64_ASSET_NAME = 'minikube-darwin-amd64';
 
 const MACOS_ARM64_ASSET_NAME = 'minikube-darwin-arm64';
 
+/**
+ * @deprecated use {@link MinikubeDownload} instead
+ */
 export class MinikubeInstaller {
   private assetNames = new Map<string, string>();
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -24,11 +24,13 @@ import * as path from 'node:path';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { MinikubeDownload } from './download';
 import type { MinikubeInstaller } from './minikube-installer';
 import {
   deleteFile,
   deleteFileAsAdmin,
   detectMinikube,
+  findMinikube,
   getMinikubeHome,
   getMinikubePath,
   installBinaryToSystem,
@@ -108,6 +110,53 @@ describe('getMinikubePath', () => {
 
     const computedPath = getMinikubePath();
     expect(computedPath).toEqual(`${existingPATH}:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin`);
+  });
+});
+
+describe('findMinikube', () => {
+  test('should use system wide first', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    const getMinikubeExtensionPathMock = vi.fn();
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      stdout: '/dummy/tmp/minikube',
+      stderr: '',
+      command: '',
+    });
+
+    const result = await findMinikube({
+      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
+    } as unknown as MinikubeDownload);
+    expect(result).toBe('/dummy/tmp/minikube');
+    expect(getMinikubeExtensionPathMock).not.toHaveBeenCalled();
+  });
+
+  test('system wide missing should fallback to local extension folder', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    const getMinikubeExtensionPathMock = vi.fn();
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('dummy error'));
+
+    getMinikubeExtensionPathMock.mockReturnValue('/extension-storage/minikube');
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+
+    const result = await findMinikube({
+      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
+    } as unknown as MinikubeDownload);
+    expect(result).toBe('/extension-storage/minikube');
+    expect(getMinikubeExtensionPathMock).toHaveBeenCalled();
+  });
+
+  test('should return undefined if not system wide and not in extension folder', async () => {
+    vi.mocked(extensionApi.env).isLinux = true;
+    const getMinikubeExtensionPathMock = vi.fn();
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('dummy error'));
+
+    getMinikubeExtensionPathMock.mockReturnValue('/extension-storage/minikube');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    const result = await findMinikube({
+      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
+    } as unknown as MinikubeDownload);
+    expect(result).toBe(undefined);
   });
 });
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -24,13 +24,11 @@ import * as path from 'node:path';
 import * as extensionApi from '@podman-desktop/api';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import type { MinikubeDownload } from './download';
 import type { MinikubeInstaller } from './minikube-installer';
 import {
   deleteFile,
   deleteFileAsAdmin,
   detectMinikube,
-  findMinikube,
   getMinikubeHome,
   getMinikubePath,
   installBinaryToSystem,
@@ -110,53 +108,6 @@ describe('getMinikubePath', () => {
 
     const computedPath = getMinikubePath();
     expect(computedPath).toEqual(`${existingPATH}:/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin`);
-  });
-});
-
-describe('findMinikube', () => {
-  test('should use system wide first', async () => {
-    vi.mocked(extensionApi.env).isLinux = true;
-    const getMinikubeExtensionPathMock = vi.fn();
-    vi.mocked(extensionApi.process.exec).mockResolvedValue({
-      stdout: '/dummy/tmp/minikube',
-      stderr: '',
-      command: '',
-    });
-
-    const result = await findMinikube({
-      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
-    } as unknown as MinikubeDownload);
-    expect(result).toBe('/dummy/tmp/minikube');
-    expect(getMinikubeExtensionPathMock).not.toHaveBeenCalled();
-  });
-
-  test('system wide missing should fallback to local extension folder', async () => {
-    vi.mocked(extensionApi.env).isLinux = true;
-    const getMinikubeExtensionPathMock = vi.fn();
-    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('dummy error'));
-
-    getMinikubeExtensionPathMock.mockReturnValue('/extension-storage/minikube');
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-
-    const result = await findMinikube({
-      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
-    } as unknown as MinikubeDownload);
-    expect(result).toBe('/extension-storage/minikube');
-    expect(getMinikubeExtensionPathMock).toHaveBeenCalled();
-  });
-
-  test('should return undefined if not system wide and not in extension folder', async () => {
-    vi.mocked(extensionApi.env).isLinux = true;
-    const getMinikubeExtensionPathMock = vi.fn();
-    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('dummy error'));
-
-    getMinikubeExtensionPathMock.mockReturnValue('/extension-storage/minikube');
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-
-    const result = await findMinikube({
-      getMinikubeExtensionPath: getMinikubeExtensionPathMock,
-    } as unknown as MinikubeDownload);
-    expect(result).toBe(undefined);
   });
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,7 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
+import type { MinikubeDownload } from './download';
 import type { MinikubeInstaller } from './minikube-installer';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -51,7 +52,12 @@ export function getMinikubeHome(): string | undefined {
   }
 }
 
-// search if minikube is available in the path
+/**
+ * search if minikube is available in the path
+ * @param pathAddition
+ * @param installer
+ * @deprecated use {@link findMinikube}
+ */
 export async function detectMinikube(pathAddition: string, installer: MinikubeInstaller): Promise<string> {
   try {
     await extensionApi.process.exec('minikube', ['version'], {
@@ -82,6 +88,20 @@ export async function detectMinikube(pathAddition: string, installer: MinikubeIn
     }
   }
   return undefined;
+}
+
+// search if minikube is available in the path or in the extension folder
+export async function findMinikube(downloader: MinikubeDownload): Promise<string | undefined> {
+  try {
+    return await whereBinary('minikube');
+  } catch (err: unknown) {
+    console.debug(err);
+  }
+
+  const extensionPath = downloader.getMinikubeExtensionPath();
+  if (fs.existsSync(extensionPath)) {
+    return extensionPath;
+  }
 }
 
 export function getBinarySystemPath(binaryName: string): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,7 +22,6 @@ import * as path from 'node:path';
 
 import * as extensionApi from '@podman-desktop/api';
 
-import type { MinikubeDownload } from './download';
 import type { MinikubeInstaller } from './minikube-installer';
 
 const macosExtraPath = '/usr/local/bin:/opt/homebrew/bin:/opt/local/bin:/opt/podman/bin';
@@ -56,7 +55,7 @@ export function getMinikubeHome(): string | undefined {
  * search if minikube is available in the path
  * @param pathAddition
  * @param installer
- * @deprecated use {@link findMinikube}
+ * @deprecated use {@link MinikubeDownload#findMinikube}
  */
 export async function detectMinikube(pathAddition: string, installer: MinikubeInstaller): Promise<string> {
   try {
@@ -88,20 +87,6 @@ export async function detectMinikube(pathAddition: string, installer: MinikubeIn
     }
   }
   return undefined;
-}
-
-// search if minikube is available in the path or in the extension folder
-export async function findMinikube(downloader: MinikubeDownload): Promise<string | undefined> {
-  try {
-    return await whereBinary('minikube');
-  } catch (err: unknown) {
-    console.debug(err);
-  }
-
-  const extensionPath = downloader.getMinikubeExtensionPath();
-  if (fs.existsSync(extensionPath)) {
-    return extensionPath;
-  }
 }
 
 export function getBinarySystemPath(binaryName: string): string {


### PR DESCRIPTION
Following https://github.com/containers/podman-desktop-extension-minikube/pull/165 simplification.

## Notable change

- Adding `findMinikube` util method. _What is the difference between `findMinikube` and `detectMinikube` ?

| `findMinikube` | `detectMinikube` |
| --- | --- |
| `findMinikube` detect binary installed by `MinikubeDownload` | `detectMinikube` detect binary installed by `MinikubeInstaller` |

> ⚠️ I cannot replace yet `detectMinikube` by `findMinikube` because the status bar still uses `MinikubeInstaller` to install the binary

-  `MinikubeInstaller` and `detectMinikube` are marked as `deprecated`

> ℹ️ Why marking them as deprecated ? Because we have duplicate logic, that will need to be removed, and I want to make small PR, so I will not delete and replace everything at once, so the follow-up PR will be ` replacing detectMinikube`, and then another `deleting unused code`.