### PR TITLE
feat: adding select version function

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -83,11 +83,10 @@ export class MinikubeDownload {
       placeHolder: 'Select Kind version to download',
     });
 
-    if (selectedRelease) {
-      return selectedRelease;
-    } else {
+    if (!selectedRelease) {
       throw new Error('No version selected');
     }
+    return selectedRelease;
   }
 
   getMinikubeExtensionPath(): string {

--- a/src/download.ts
+++ b/src/download.ts
@@ -69,17 +69,17 @@ export class MinikubeDownload {
   }
 
   async selectVersion(cliInfo?: extensionApi.CliTool): Promise<MinikubeGithubReleaseArtifactMetadata> {
-    let lastReleasesMetadata = await this.grabLatestsReleasesMetadata();
+    let releasesMetadata = await this.grabLatestsReleasesMetadata();
 
-    if (lastReleasesMetadata.length === 0) throw new Error('cannot grab minikube releases');
+    if (releasesMetadata.length === 0) throw new Error('cannot grab minikube releases');
 
     // if the user already has an installed version, we remove it from the list
     if (cliInfo) {
-      lastReleasesMetadata = lastReleasesMetadata.filter(release => release.tag.slice(1) !== cliInfo.version);
+      releasesMetadata = releasesMetadata.filter(release => release.tag.slice(1) !== cliInfo.version);
     }
 
     // Show the quickpick
-    const selectedRelease = await window.showQuickPick(lastReleasesMetadata, {
+    const selectedRelease = await window.showQuickPick(releasesMetadata, {
       placeHolder: 'Select Kind version to download',
     });
 


### PR DESCRIPTION
Following https://github.com/containers/podman-desktop-extension-minikube/pull/171. Given the podman desktop core api, we need to have a function handling the user selection for the version to install.

To be able to provide the `CliToolInstaller#selectversion`[^1] function, we need to have the quick pick logic. As recommended in https://github.com/containers/podman-desktop-extension-minikube/pull/171#discussion_r1806230966 making the logic part of the minikubeDownload as it need the object to collect the releases. 

[^1]: https://podman-desktop.io/api/interfaces/CliToolInstaller#selectversion