### PR TITLE
feat: adding install method on minikube download

### DIFF
--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -239,6 +239,48 @@ describe('selectVersion', () => {
   });
 });
 
+describe('install', () => {
+  test('install should download the asset provided', async () => {
+    (env.isWindows as boolean) = true;
+    const release: MinikubeGithubReleaseArtifactMetadata = {
+      tag: 'v1.2.3',
+      id: 55,
+      label: 'v1.5.2',
+    };
+
+    const minikubeDownload = new MinikubeDownload(extensionContext, octokitMock);
+
+    vi.spyOn(minikubeDownload, 'download').mockResolvedValue('/download/asset/path');
+
+    vi.mocked(processCore.exec).mockResolvedValue({
+      stdout: '',
+      stderr: '',
+      command: '',
+    });
+
+    await minikubeDownload.install(release);
+    expect(minikubeDownload.download).toHaveBeenCalledWith(release);
+  });
+
+  test('install fallback to download path if install system wide failed', async () => {
+    (env.isWindows as boolean) = true;
+    const release: MinikubeGithubReleaseArtifactMetadata = {
+      tag: 'v1.2.3',
+      id: 55,
+      label: 'v1.5.2',
+    };
+
+    const minikubeDownload = new MinikubeDownload(extensionContext, octokitMock);
+
+    vi.spyOn(minikubeDownload, 'download').mockResolvedValue('/download/asset/path');
+
+    vi.mocked(processCore.exec).mockRejectedValue(new Error('random error'));
+
+    const file = await minikubeDownload.install(release);
+    expect(file).toBe('/download/asset/path');
+  });
+});
+
 describe('findMinikube', () => {
   test('should use system wide first', async () => {
     (env.isWindows as boolean) = true;

--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -291,7 +291,10 @@ describe('install', () => {
   });
 
   test('user should be notified if system-wide installed failed', async () => {
-    (env.isWindows as boolean) = true;
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+    });
+    (env.isLinux as boolean) = true;
     const release: MinikubeGithubReleaseArtifactMetadata = {
       tag: 'v1.2.3',
       id: 55,
@@ -307,10 +310,11 @@ describe('install', () => {
     vi.spyOn(minikubeDownload, 'download').mockResolvedValue('/download/asset/path');
 
     const file = await minikubeDownload.install(release);
+
     expect(file).toBe('/download/asset/path');
     expect(processCore.exec).toHaveBeenCalled();
     expect(window.showErrorMessage).toHaveBeenCalledWith(
-      'Something went wrong while trying to install minikube system-wide: Error: Something horrible',
+      'Something went wrong while trying to install minikube system-wide: Error: Error making binary executable: Error: Something horrible',
     );
   });
 });

--- a/src/download.ts
+++ b/src/download.ts
@@ -25,7 +25,7 @@ import type { Octokit } from '@octokit/rest';
 import type * as extensionApi from '@podman-desktop/api';
 import { env, window } from '@podman-desktop/api';
 
-import { whereBinary } from './util';
+import { installBinaryToSystem, whereBinary } from './util';
 
 export interface MinikubeGithubReleaseArtifactMetadata extends extensionApi.QuickPickItem {
   tag: string;
@@ -111,6 +111,16 @@ export class MinikubeDownload {
     if (fs.existsSync(extensionPath)) {
       return extensionPath;
     }
+  }
+
+  async install(release: MinikubeGithubReleaseArtifactMetadata): Promise<string> {
+    let destFile = await this.download(release);
+    try {
+      destFile = await installBinaryToSystem(destFile, 'minikube');
+    } catch (err: unknown) {
+      console.debug('Cannot install system wide', err);
+    }
+    return destFile;
   }
 
   // Download minikube from the artifact metadata: MinikubeGithubReleaseArtifactMetadata

--- a/src/download.ts
+++ b/src/download.ts
@@ -113,12 +113,28 @@ export class MinikubeDownload {
     }
   }
 
+  /**
+   * Given a {@link MinikubeGithubReleaseArtifactMetadata} it will be downloaded to the
+   * extension folder, then on user approval tried to be installed system-wide
+   * @param release the release to download and install
+   */
   async install(release: MinikubeGithubReleaseArtifactMetadata): Promise<string> {
     let destFile = await this.download(release);
+
+    const result = await window.showInformationMessage(
+      `minikube binary has been successfully downloaded.\n\nWould you like to install it system-wide for accessibility on the command line? This will require administrative privileges.`,
+      'Yes',
+      'Cancel',
+    );
+
+    if (result !== 'Yes') return destFile;
+
     try {
       destFile = await installBinaryToSystem(destFile, 'minikube');
     } catch (err: unknown) {
-      console.debug('Cannot install system wide', err);
+      console.error(err);
+      await window.showErrorMessage(`Something went wrong while trying to install minikube system-wide: ${err}`);
+      // we yet return the extension-folder path to still allow the binary downloaded to be registered by the extension
     }
     return destFile;
   }


### PR DESCRIPTION
Following https://github.com/containers/podman-desktop-extension-minikube/pull/172

When we `CliTool#registerInstall` and `CliTool#registerUpdate` we need a method to download and install the binary, instead of repeating the code between those two object, we can create a unique method `install` taking the artifact as argument. Why ? Because we have a bit of logic: 

1. download
2. try to install system wide
3. if system success return system path otherwise return download path

And having this method avoid repeating the same lines.

> ℹ️ Trust the process... almost at the end :)