### PR TITLE
feat: adding utility method to get minikube executable version

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -31,6 +31,7 @@ import {
   detectMinikube,
   getMinikubeHome,
   getMinikubePath,
+  getMinikubeVersion,
   installBinaryToSystem,
   whereBinary,
 } from './util';
@@ -377,5 +378,28 @@ describe('deleteFileAsAdmin', () => {
     expect(extensionApi.process.exec).toHaveBeenCalledWith('rm', ['/dummy/minikube'], {
       isAdmin: true,
     });
+  });
+});
+
+describe('getMinikubeVersion', () => {
+  test('error should propagate', async () => {
+    vi.mocked(extensionApi.process.exec).mockRejectedValue(new Error('something wrong'));
+
+    await expect(async () => {
+      await getMinikubeVersion('/dummy/minikube');
+    }).rejects.toThrowError('something wrong');
+
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('/dummy/minikube', ['version', '--short']);
+  });
+
+  test('should format the version output', async () => {
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      stdout: 'v1.5.3',
+      stderr: '',
+      command: '',
+    });
+
+    const result = await getMinikubeVersion('/dummy/minikube');
+    expect(result).toBe('1.5.3');
   });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -147,6 +147,11 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
   }
 }
 
+export async function getMinikubeVersion(executable: string): Promise<string> {
+  const result = await extensionApi.process.exec(executable, ['version', '--short']);
+  return result.stdout.replace('v', '').trim();
+}
+
 /**
  * Given an executable name will find where it is installed on the system
  * @param executable


### PR DESCRIPTION
## Description

Adding the last[^1] method required to be able to manage the lifecycle of the CLI Tool: When we `createCliTool` we need to provide the version, if we only provide the path, it will not be displayed in the CliTool. Therefore we need an utility method to get the version.

## Unit tests

- [x] unit tests ensure it is nice 🌹 

[^1]: Maybe I am lying, only the future will tell.